### PR TITLE
feat: scale down power when cmd=raise & raise ang > 90deg

### DIFF
--- a/Drive_2_0_fieldCentric.java
+++ b/Drive_2_0_fieldCentric.java
@@ -265,7 +265,11 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
           armraise.setPower(0.265);
         } else {
           armraise.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-          armraise.setPower(driverCmd_ArmRaise * MAX_ARM_RAISE_POWER);
+          if (armRaisePositionTicks > 683.55) {
+            armraise.setPower(0.33 * driverCmd_ArmRaise * MAX_ARM_RAISE_POWER);
+          } else {
+            armraise.setPower(driverCmd_ArmRaise * MAX_ARM_RAISE_POWER);
+          }
         }
       } else {  // isArmCmdDown
         isArmHolding = false;


### PR DESCRIPTION
@Harrison879 added this code at our 12/26/2023 programming meeting to scale down the motor power when driver 2 is commanding the arm to raise & the raise motor position is > 90 degrees.  

Quick experiments at the bot spot showed that this allows this driver to keep the stick @ max raise, and get a reasonable arm motion into the backdrop.  This seems to prevent this driver from hitting the backdrop hard enough to de-score pixels already on the board (at least, without the "assistance" of driver 1).