### PR TITLE
Modify 4 main auto programs to use april tag adjustments

### DIFF
--- a/AutoCommon.java
+++ b/AutoCommon.java
@@ -1,6 +1,7 @@
 // Get package/imports
 package org.firstinspires.ftc.teamcode;
 import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.hardware.IMU;
 import org.firstinspires.ftc.vision.VisionPortal;
 import org.firstinspires.ftc.vision.apriltag.AprilTagProcessor;
 import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
@@ -11,12 +12,14 @@ import com.qualcomm.robotcore.hardware.Servo;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
+import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
 import org.openftc.easyopencv.OpenCvWebcam;
 import org.openftc.easyopencv.OpenCvCamera;
 import org.openftc.easyopencv.OpenCvCameraFactory;
 import org.openftc.easyopencv.OpenCvCameraRotation;
 import org.openftc.easyopencv.OpenCvPipeline;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 
 // Begin code
 public class AutoCommon extends LinearOpMode {
@@ -27,6 +30,8 @@ public class AutoCommon extends LinearOpMode {
   // additional AprilTag vision objects
   private AprilTagProcessor aprilTag;
   private VisionPortal visionPortal;
+  
+  private IMU imu;
 
   // Declare motors/servos
   private DcMotor frontleft, rearleft, frontright, rearright, armextend, armraise;
@@ -67,6 +72,7 @@ public class AutoCommon extends LinearOpMode {
   double FindPropMinChroma() { return findPropPL.min_chroma; }
   int FindPropMaxX() { return findPropPL.max_x; }
   int FindPropMaxY() { return findPropPL.max_y; }
+  
 
   // This class isn't an opmode that should be run on the robot
   // but it extends (inherits from) LinearOpMode so it can access
@@ -87,6 +93,9 @@ public class AutoCommon extends LinearOpMode {
     grabber = hardwareMap.get(Servo.class, "grabber");
     flipper = hardwareMap.get(Servo.class, "flipper");
     armlimiter = hardwareMap.get(Servo.class, "armlimiter");
+    
+    imu = hardwareMap.get(IMU.class, "imu");  // Retrieve the IMU from the hardware map
+    imu.initialize(new IMU.Parameters(new RevHubOrientationOnRobot(RevHubOrientationOnRobot.LogoFacingDirection.LEFT,RevHubOrientationOnRobot.UsbFacingDirection.FORWARD)));
     
     rearright.setDirection(DcMotorSimple.Direction.REVERSE);
     frontleft.setDirection(DcMotorSimple.Direction.REVERSE);
@@ -540,4 +549,6 @@ public class AutoCommon extends LinearOpMode {
     return 0.75 - det.ftcPose.x;  // assumes: the more to camera's right the tag is, the more negative this drive_right adjust should be
                                   // assumes: no additional/subsequent right/left drive command is pending
   }
+  
+  double getImuYaw() { return imu.getRobotYawPitchRollAngles().getYaw(AngleUnit.DEGREES); }
 }

--- a/AutoCommon.java
+++ b/AutoCommon.java
@@ -269,8 +269,8 @@ public class AutoCommon extends LinearOpMode {
       armraise.setTargetPosition(0);
     } else {                 // Change arm position (in degrees) by input (negative or positive)
       raise_lower = raise_lower * ARM_RAISE_TICKS_PER_DEG;  // convert degrees to ticks
-      raise_lower = ((int) (raise_lower) + armraise.getCurrentPosition());  // Set variable to current position plus change
-      armraise.setTargetPosition(raise_lower);  // Set target position to variable
+      raise_lower = (double) ((int) (raise_lower) + armraise.getCurrentPosition());  // Set variable to current position plus change
+      armraise.setTargetPosition((int) raise_lower);  // Set target position to variable
     }
     armraise.setMode(DcMotor.RunMode.RUN_TO_POSITION);
     armraise.setPower(Math.abs(power));

--- a/BlueBackPixel.java
+++ b/BlueBackPixel.java
@@ -84,8 +84,8 @@ public class BlueBackPixel extends LinearOpMode
         lib.armraisewait(30, 0.09);        // raise arm last 45 deg
 
         AprilTagDetection tagInfo = lib.getAprilTag_BlueLeft();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6.0 + yAdjustment, xAdjustment, 0, 0.2);       // REV last 4" to board
         lib.openClampWait();          // release pixel on board
@@ -124,8 +124,8 @@ public class BlueBackPixel extends LinearOpMode
         lib.armraise(30, 0.127);        // slow down to avoid tipping over
 
         AprilTagDetection tagInfo = lib.getAprilTag_BlueMiddle();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);       // REV last 5" to board
         sleep(300);
@@ -165,8 +165,8 @@ public class BlueBackPixel extends LinearOpMode
         lib.armraise(30, 0.127);        // slow down to avoid tipping over
 
         AprilTagDetection tagInfo = lib.getAprilTag_BlueRight();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
         
         lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);       // REV last 5" to board
         lib.openClampWait();          // release pixel on board

--- a/BlueBackPixel.java
+++ b/BlueBackPixel.java
@@ -16,6 +16,8 @@ public class BlueBackPixel extends LinearOpMode
   @Override
   public void runOpMode() 
   {
+    double xAdjustment = 0, yAdjustment = 0;  // default to no adjustments in case our tag isn't detected
+
     ElapsedTime programTime = new ElapsedTime();
 
     // See FindPropVisInitData.java for calibration guide
@@ -81,29 +83,11 @@ public class BlueBackPixel extends LinearOpMode
         lib.reverseFlipper();           // put flipper in rev pos for placing pixel on board
         lib.armraisewait(30, 0.09);        // raise arm last 45 deg
 
-        double xAdjustment = 0;
-        double yAdjustment = 0;
+        AprilTagDetection tagInfo = lib.getAprilTag_BlueLeft();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
 
-        int loop = 0;
-        while(programTime.seconds() < 25.0) { //loop < 1000000) {  //!foundtag1) {
-          AprilTagDetection det1 = lib.getAprilTagDetection(1);
-          AprilTagDetection det2 = lib.getAprilTagDetection(2);
-          AprilTagDetection det3 = lib.getAprilTagDetection(3);
-          if (det1 != null) {
-          telemetry.addData("det1.x:", det1.ftcPose.x);
-          telemetry.addData("det1.y:", det1.ftcPose.y);
-          
-          xAdjustment = 0.75 - det1.ftcPose.x;
-          yAdjustment = 13.5 - det1.ftcPose.y;
-          }
-          if (det3 != null) {
-          telemetry.addData("det3.x:", det3.ftcPose.x);
-          telemetry.addData("det3.y:", det3.ftcPose.y);
-          }
-          telemetry.update();  
-        }
-        
-        lib.drive(-5.2 + yAdjustment, xAdjustment, 0, 0.2);       // REV last 4" to board
+        lib.drive(-6.0 + yAdjustment, xAdjustment, 0, 0.2);       // REV last 4" to board
         lib.openClampWait();          // release pixel on board
         sleep(350);                // wait for pixel
         lib.openClampLittle();        // open clamp slightly
@@ -134,11 +118,16 @@ public class BlueBackPixel extends LinearOpMode
         lib.drive(0, 0, 108, DRIVE_POWER);      // CW 108 to face away from backdrop
         sleep(50);
         lib.armraise(100, 0.3);         // raise arm 120 deg (all the way back/up for placing pixel on board)
-        lib.drive(-24, 0, 0, DRIVE_POWER);       // FWD 25.5" toward backdrop
+        lib.drive(-23, 0, 0, DRIVE_POWER);       // FWD 25.5" toward backdrop
         lib.reverseFlipper();           // put flipper in rev pos for placing pixel on board
         lib.drive(0, -9, 0, DRIVE_POWER);       // left 10" along backdrop
         lib.armraise(30, 0.127);        // slow down to avoid tipping over
-        lib.drive(-5, 0, 0, 0.2);       // REV last 5" to board
+
+        AprilTagDetection tagInfo = lib.getAprilTag_BlueMiddle();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);       // REV last 5" to board
         sleep(300);
         lib.openClampWait();          // release pixel on board
         sleep(400);
@@ -168,13 +157,18 @@ public class BlueBackPixel extends LinearOpMode
         lib.drive(-2, 0, 0, DRIVE_POWER); // back up 2" to clear spike mark
         lib.drive(0, 0, 40, DRIVE_POWER);      // CW 40 to face away from backdrop
         sleep(50);
-        lib.drive(-24, 0, 0, DRIVE_POWER);       // FWD 26" toward backdrop
+        lib.drive(-21.2, 0, 0, DRIVE_POWER);       // FWD 26" toward backdrop
         lib.armraise(100, 0.3);         // raise arm 120 deg (all the way back/up for placing pixel on board)
         //drive(0, 0, 180, DRIVE_POWER);      // CW 180 deg to back into backdrop
         lib.reverseFlipper();           // put flipper in rev pos for placing pixel on board
         lib.drive(0, -18, 0, DRIVE_POWER);       // left 4" along backdrop
         lib.armraise(30, 0.127);        // slow down to avoid tipping over
-        lib.drive(-3.2, 0, 0, 0.2);       // REV last 5" to board
+
+        AprilTagDetection tagInfo = lib.getAprilTag_BlueRight();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+        
+        lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);       // REV last 5" to board
         lib.openClampWait();          // release pixel on board
         sleep(400);
         lib.drive(2 , 0, 0, 0.25);       // forward 2" from board

--- a/BlueFrontPixel.java
+++ b/BlueFrontPixel.java
@@ -2,6 +2,7 @@ package org.firstinspires.ftc.teamcode;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import org.firstinspires.ftc.robotcore.external.JavaUtil;
+import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 
 @Autonomous(name = "BlueFrontPixel")
 public class BlueFrontPixel extends LinearOpMode 
@@ -14,6 +15,8 @@ public class BlueFrontPixel extends LinearOpMode
   @Override
   public void runOpMode() 
   {
+    double xAdjustment = 0, yAdjustment = 0;  // default to no adjustments in case our tag isn't detected
+
     // See FindPropVisInitData.java for calibration guide
     FindPropVisInitData visInitData = new FindPropVisInitData();
     visInitData.ColorChannel = 2;               // channel 1: red, channel 2: blue
@@ -43,6 +46,7 @@ public class BlueFrontPixel extends LinearOpMode
     }
 
     lib.FindPropSetEnableDetection(false);
+    lib.initAprilTag();
 
     // wait for user to press start on Driver Station
     waitForStart();
@@ -75,7 +79,12 @@ public class BlueFrontPixel extends LinearOpMode
         lib.armraisewait(100, 0.2);             // raise to backdrop
         lib.reverseFlipper();
         lib.armraisewait(30,0.2);               
-        lib.drive(-6, 0, 0, DRIVE_POWER);       // go backwards to put on pixel
+
+        AprilTagDetection tagInfo = lib.getAprilTag_BlueLeft();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6 + yAdjustment, xAdjustment, 0, DRIVE_POWER);       // go backwards to put on pixel
         lib.openClamp();
         lib.drive(4.5, 0, 0, DRIVE_POWER);      // go forwards
         lib.normalFlipper();
@@ -111,7 +120,12 @@ public class BlueFrontPixel extends LinearOpMode
         lib.armraisewait(100, 0.2);             // raise to backdrop
         lib.reverseFlipper();
         lib.armraisewait(30,0.2);               
-        lib.drive(-6, 0, 0, DRIVE_POWER);       // go backwards to put on pixel
+
+        AprilTagDetection tagInfo = lib.getAprilTag_BlueMiddle();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6 + yAdjustment, xAdjustment, 0, DRIVE_POWER);       // go backwards to put on pixel
         lib.openClamp();
         lib.drive(4.5, 0, 0, DRIVE_POWER);      // go forwards
         lib.normalFlipper();
@@ -136,14 +150,18 @@ public class BlueFrontPixel extends LinearOpMode
         lib.drive(0, -5.5, 0, DRIVE_POWER);       // line up robot to move forward
         lib.drive(30.5, 0, 0, 0.65);       // Drive 35" forward to bridge
         lib.drive(0, 0, -92, 0.65);      // Rotate CCW 90 dg to face back wall
-        lib.drive(75, 0, 0, 0.65);      // Drive forward 6' 4" to parking zone, with second pixel
+        lib.drive(71.5, 0, 0, 0.65);      // Drive forward 6' 4" to parking zone, with second pixel
         lib.drive(0, -16, 0, DRIVE_POWER);    // line up to right side
         lib.drive(0, 0, 180, 0.65);           // turn around
         lib.armraisewait(100, 0.2);           // lift arm to backdrop
         lib.reverseFlipper();
         lib.armraisewait(30,0.2);             
-        lib.drive(-2.5, 0, 0, DRIVE_POWER);     // drive back to backdrop
-        sleep(100);
+
+        AprilTagDetection tagInfo = lib.getAprilTag_BlueRight();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6 + yAdjustment, xAdjustment, 0, DRIVE_POWER);     // drive back to backdrop
         lib.openClamp();
         lib.drive(4.5, 0, 0, DRIVE_POWER);    // drive forward to let pixel drop
         lib.normalFlipper();

--- a/BlueFrontPixel.java
+++ b/BlueFrontPixel.java
@@ -42,6 +42,7 @@ public class BlueFrontPixel extends LinearOpMode
       telemetry.addData(" -MIN_CHROMA: ", lib.FindPropMinChroma());
       telemetry.addData(" -MAX_X: ", lib.FindPropMaxX());
       telemetry.addData(" -MAX_Y: ", lib.FindPropMaxY());
+      telemetry.addData("Yaw", lib.getImuYaw());
       telemetry.update();
     }
 
@@ -71,10 +72,15 @@ public class BlueFrontPixel extends LinearOpMode
 
         lib.drive(-7.5, 0, 0, DRIVE_POWER);        // drive back 5"
         lib.drive(0, 0, 55, DRIVE_POWER);      // CCW 55 to face forward
-        lib.drive(29.5, 0, 0, 0.65);       // Drive 35" forward to bridge
-        lib.drive(0, 0, -90, 0.65);      // Rotate CCW 90 dg to face back wall
-        lib.drive(75, 0, 0, 0.65);      // Drive forward 6' 4" to parking zone, with second pixel
-        lib.drive(0, -32.2, 0, DRIVE_POWER);    // line up with left side
+        lib.drive(29.5, 0, 0, 0.7);       // Drive 35" forward to bridge
+        double imuRotation = lib.getImuYaw();
+        if (imuRotation != 0) {
+          lib.drive(0, 0, -(90 - imuRotation), 0.65);      // Rotate CCW 90 dg to face back wall
+        } else {
+          lib.drive(0, 0, -90, 0);
+        }
+        lib.drive(75, 0, 0, 0.75);      // Drive forward 6' 4" to parking zone, with second pixel
+        lib.drive(0, -32.2, 0, 0.75);    // line up with left side
         lib.drive(0, 0, 180, 0.65);             // rotate to back side
         lib.armraisewait(100, 0.2);             // raise to backdrop
         lib.reverseFlipper();
@@ -88,10 +94,10 @@ public class BlueFrontPixel extends LinearOpMode
         lib.openClamp();
         lib.drive(4.5, 0, 0, DRIVE_POWER);      // go forwards
         lib.normalFlipper();
-        lib.armraisewait(-110, 0.4);            // bring arm back down
-        lib.armraise(-30,0.2);
+        lib.armraisewait(-70, 0.4);            // bring arm back down
+        lib.armraise(-70,0.2);
         
-        lib.drive(-3, -19, 0, DRIVE_POWER);     // drive to park
+        lib.drive(-3, -19, 0, 0.7);     // drive to park
         lib.drive(-5, 0, 0, DRIVE_POWER);     // drive to park
         
         // release motors
@@ -112,9 +118,14 @@ public class BlueFrontPixel extends LinearOpMode
         sleep(100);
         
         lib.drive(31, 0, 0, DRIVE_POWER);       // drive to bridge
-        sleep(100);
-        lib.drive(0, 0, -90, 0.65);      // Rotate CCW 90 dg to face back wall
-        lib.drive(88, 0, 0, 0.65);       // Drive forward 83" to parking zone, with second pixel
+        sleep(10000);
+        double imuRotation = lib.getImuYaw();
+        if (imuRotation != 0) {
+          lib.drive(0, 0, -(90 - imuRotation), 0.65);      // Rotate CCW 90 dg to face back wall
+        } else {
+          lib.drive(0, 0, -90, 0);
+        }
+        lib.drive(88, 0, 0, 0.9);       // Drive forward 83" to parking zone, with second pixel
         lib.drive(0, -28, 0, DRIVE_POWER);    // line up with middle
         lib.drive(0, 0, 180, 0.65);             // rotate to back side
         lib.armraisewait(100, 0.2);             // raise to backdrop
@@ -149,7 +160,12 @@ public class BlueFrontPixel extends LinearOpMode
         lib.drive(0, 0, -35, DRIVE_POWER);      // CCW 35 to face forward
         lib.drive(0, -5.5, 0, DRIVE_POWER);       // line up robot to move forward
         lib.drive(30.5, 0, 0, 0.65);       // Drive 35" forward to bridge
-        lib.drive(0, 0, -92, 0.65);      // Rotate CCW 90 dg to face back wall
+        double imuRotation = lib.getImuYaw();
+        if (imuRotation != 0) {
+          lib.drive(0, 0, -(90 - imuRotation), 0.65);      // Rotate CCW 90 dg to face back wall
+        } else {
+          lib.drive(0, 0, -90, 0);
+        }
         lib.drive(71.5, 0, 0, 0.65);      // Drive forward 6' 4" to parking zone, with second pixel
         lib.drive(0, -16, 0, DRIVE_POWER);    // line up to right side
         lib.drive(0, 0, 180, 0.65);           // turn around

--- a/BlueFrontPixel.java
+++ b/BlueFrontPixel.java
@@ -81,8 +81,8 @@ public class BlueFrontPixel extends LinearOpMode
         lib.armraisewait(30,0.2);               
 
         AprilTagDetection tagInfo = lib.getAprilTag_BlueLeft();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6 + yAdjustment, xAdjustment, 0, DRIVE_POWER);       // go backwards to put on pixel
         lib.openClamp();
@@ -122,8 +122,8 @@ public class BlueFrontPixel extends LinearOpMode
         lib.armraisewait(30,0.2);               
 
         AprilTagDetection tagInfo = lib.getAprilTag_BlueMiddle();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6 + yAdjustment, xAdjustment, 0, DRIVE_POWER);       // go backwards to put on pixel
         lib.openClamp();
@@ -158,8 +158,8 @@ public class BlueFrontPixel extends LinearOpMode
         lib.armraisewait(30,0.2);             
 
         AprilTagDetection tagInfo = lib.getAprilTag_BlueRight();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6 + yAdjustment, xAdjustment, 0, DRIVE_POWER);     // drive back to backdrop
         lib.openClamp();

--- a/Drive_2_0_fieldCentric.java
+++ b/Drive_2_0_fieldCentric.java
@@ -24,7 +24,7 @@ import org.firstinspires.ftc.vision.apriltag.AprilTagProcessor;
 public class Drive_2_0_fieldCentric extends LinearOpMode {
 
   // CONSTANTS USED TO ADJUST PROGRAM:
-  double MAX_DRIVE_MOTOR_POWER = 0.75;  // up to 1.0
+  double MAX_DRIVE_MOTOR_POWER = 1.0;  // up to 1.0
   boolean IS_FIELD_CENTRIC = false;
   double MAX_ARM_RAISE_POWER = 0.45;
   double MAX_ARM_LOWER_POWER = 0.16;
@@ -168,9 +168,9 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
       double currTimeMs = currentTime.milliseconds();
       // DRIVE CONTROLS MAP
       // :mechanum drive 
-      driverCmd_Right=gamepad1.right_stick_x;
-      driverCmd_Fwd=-gamepad1.right_stick_y;  // negative because stick_y is up=neg, we want up=pos
-      driverCmd_Rotate=gamepad1.left_stick_x;
+      driverCmd_Right=Math.pow(gamepad1.right_stick_x, 3);
+      driverCmd_Fwd=-Math.pow(gamepad1.right_stick_y, 3);  // negative because stick_y is up=neg, we want up=pos
+      driverCmd_Rotate=Math.pow(gamepad1.left_stick_x, 3);
       telemetry.addData("driverCmdFwd", driverCmd_Fwd);
       // :arm rotate (aka raise/lower) & arm extend
       driverCmd_ArmRaise = -gamepad2.left_stick_y;

--- a/Drive_2_0_fieldCentric.java
+++ b/Drive_2_0_fieldCentric.java
@@ -56,11 +56,20 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
   private AprilTagProcessor aprilTag;
   private VisionPortal visionPortal;
 
+  private AutoCommon lib;
   /**`
    * This function is executed when this OpMode is selected from the Driver Station.
    */
   @Override
   public void runOpMode() {
+    
+    FindPropVisInitData visInitData = new FindPropVisInitData();
+      lib = new AutoCommon(
+      hardwareMap,
+      visInitData);
+    
+    lib.initAprilTag();
+
     // INIT:
     // :find our HW in the hardwareMap:
     //   IMU:
@@ -87,8 +96,7 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
     Servo armlimiter = hardwareMap.get(Servo.class, "armlimiter");
     
     // :set motor directions so that pos/neg tick encoder positions make sense
-    frontright.setDirection(DcMotorSimple.Direction.REVERSE);
-    rearleft.setDirection(DcMotorSimple.Direction.REVERSE);
+    // AutoCommon init sets the drive motor directions
     lifter.setDirection(DcMotorSimple.Direction.REVERSE);
     armraise.setDirection(DcMotorSimple.Direction.REVERSE);
     // :reset motor encoder positions to zero
@@ -212,10 +220,10 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
       // This ensures all the powers maintain the same ratio,
       // but only if at least one is out of the range [-MAX_DRIVE_MOTOR_POWER, MAX_DRIVE_MOTOR_POWER]
       double denominator = Math.max(Math.abs(robotCmd_Fwd) + Math.abs(robotCmd_Right) + Math.abs(robotCmd_Rotate), 1.0);
-      double frontLeftPower = MAX_DRIVE_MOTOR_POWER * (robotCmd_Fwd - robotCmd_Right + robotCmd_Rotate) / denominator;
-      double frontRightPower = MAX_DRIVE_MOTOR_POWER * (robotCmd_Fwd - robotCmd_Right - robotCmd_Rotate) / denominator;
-      double backLeftPower = MAX_DRIVE_MOTOR_POWER * (robotCmd_Fwd + robotCmd_Right + robotCmd_Rotate) / denominator;
-      double backRightPower = MAX_DRIVE_MOTOR_POWER * (robotCmd_Fwd + robotCmd_Right - robotCmd_Rotate) / denominator;
+      double frontLeftPower = MAX_DRIVE_MOTOR_POWER * (-robotCmd_Fwd + robotCmd_Right - robotCmd_Rotate) / denominator;
+      double frontRightPower = MAX_DRIVE_MOTOR_POWER * (-robotCmd_Fwd + robotCmd_Right + robotCmd_Rotate) / denominator;
+      double backLeftPower = MAX_DRIVE_MOTOR_POWER * (-robotCmd_Fwd - robotCmd_Right - robotCmd_Rotate) / denominator;
+      double backRightPower = MAX_DRIVE_MOTOR_POWER * (-robotCmd_Fwd - robotCmd_Right + robotCmd_Rotate) / denominator;
       // Set motor powers
       frontleft.setPower(frontLeftPower);
       frontright.setPower(frontRightPower);

--- a/Drive_2_0_fieldCentric.java
+++ b/Drive_2_0_fieldCentric.java
@@ -1,12 +1,14 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.eventloop.opmode.Disabled;
+import com.qualcomm.robotcore.hardware.VoltageSensor;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.util.ElapsedTime;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.qualcomm.robotcore.hardware.Blinker;
 import com.qualcomm.robotcore.hardware.HardwareDevice;
 import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.Servo;
 import com.qualcomm.robotcore.hardware.IMU;
@@ -17,6 +19,7 @@ import org.firstinspires.ftc.robotcore.external.hardware.camera.WebcamName;
 import org.firstinspires.ftc.vision.VisionPortal;
 import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 import org.firstinspires.ftc.vision.apriltag.AprilTagProcessor;
+import java.util.List;
 
 // @Disabled
 
@@ -94,6 +97,8 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
     Servo droneLauncher = hardwareMap.get(Servo.class, "dronelauncher");
     // Arm Limiter Servo
     Servo armlimiter = hardwareMap.get(Servo.class, "armlimiter");
+    // Voltage sensor: 
+    VoltageSensor ControlHub_VoltageSensor = hardwareMap.get(VoltageSensor.class, "Control Hub");
     
     // :set motor directions so that pos/neg tick encoder positions make sense
     // AutoCommon init sets the drive motor directions
@@ -111,6 +116,7 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
     armextend.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
     armraise.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
     lifter.setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+    launchMotor.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
     
     // Variables for driver commands
     double driverCmd_Fwd, driverCmd_Right, driverCmd_Rotate;
@@ -417,11 +423,46 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
       
       if (true) {
         telemetry.addLine("--------------------");
-        if (driverCmd_LaunchDrone /*&& !droneLaunched*/) {
+        if (driverCmd_LaunchDrone && !droneLaunched) {
           droneLaunched = true;
-          launchMotor.setPower(1);
           telemetry.addLine("Launching drone...");
-          sleep(2000);
+          AprilTagDetection look43 = lib.getAprilTagDetection(3);
+          AprilTagDetection look44 = lib.getAprilTagDetection(4);
+          if (look43 != null) {
+            telemetry.addLine("found tag 3...");
+            telemetry.update();
+            double yDistance = look43.ftcPose.y;
+            lib.drive(12 - yDistance, 0, 0, 0);
+            //double zRotation = imu.getRobotYawPitchRollAngles().getYaw(AngleUnit.DEGREES);
+            //lib.drive(0, 0, 90 + zRotation, 0);
+          } else if (look44 != null) {
+            telemetry.addLine("found tag 4...");
+            telemetry.update();
+            //sleep(2500);
+            double yDistance = look44.ftcPose.y;
+            lib.drive(12 - yDistance, 0, 0, 0);
+            //double imuYaw = imu.getRobotYawPitchRollAngles().getYaw(AngleUnit.DEGREES);
+            //if (imuYaw != 0.0) {
+            //  lib.drive(0, 0, imuYaw - 90, 0);
+            //}
+          } else {
+            telemetry.addLine("no tags found...");
+            telemetry.addLine("Hopefully you lined it up right");
+            telemetry.update();
+            //sleep(2500);
+          }
+          double batt = 13.123;
+          double adjVel = 2450.123;
+          batt = ControlHub_VoltageSensor.getVoltage();
+          double baseVelocity = 2450;
+          adjVel = (12.9 / batt + 1.0) / 2.0 * baseVelocity;
+          
+          ((DcMotorEx)launchMotor).setVelocity(adjVel);   // 2450   2300   3500
+          sleep(200);   // 270
+          //droneVelAct = ((DcMotorEx)launchMotor).getVelocity();  // .getVelocity(AngleUnit.DEGREES);
+          ((DcMotorEx)launchMotor).setVelocity(0);
+
+          telemetry.update();
           launchMotor.setPower(0);
         } else {
           if (!droneLaunched) {
@@ -435,11 +476,7 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
         telemetry.addData("Time until ready to launch", ((int) 90 - (currTimeMs/1000)));
       }
       
-      if (false) { // Get april tags
-        initAprilTag();
-        // detection.ftcPose.x, detection.ftcPose.y, detection.ftcPose.z 
-      }
-      
+
       telemetry.addData("DriverCmd_ToLowest", driverCmd_ArmToLowest);
       telemetry.addData("DriverCmd_GrabTopPixel", driverCmd_GrabTopPixel);
       telemetry.addData("armraise target position", armraise.getTargetPosition());
@@ -453,33 +490,5 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
       telemetry.update();
     }  // END OF WHILE LOOP
   }  // END OF RUN OPMODE FUNCTION
-      
-      private void initAprilTag() {
-
-        // Create the AprilTag processor.
-        aprilTag = new AprilTagProcessor.Builder()
-
-            .build();
-
-        // Create the vision portal by using a builder.
-        VisionPortal.Builder builder = new VisionPortal.Builder();
-
-        // Set the camera (webcam vs. built-in RC phone camera).
-        if (USE_WEBCAM) {
-            builder.setCamera(hardwareMap.get(WebcamName.class, "Webcam"));
-        } else {
-            builder.setCamera(BuiltinCameraDirection.BACK);
-        }
-
-        // Set and enable the processor.
-        builder.addProcessor(aprilTag);
-
-        // Build the Vision Portal, using the above settings.
-        visionPortal = builder.build();
-
-        // Disable or re-enable the aprilTag processor at any time.
-        //visionPortal.setProcessorEnabled(aprilTag, true);
-
-      }   // end method initAprilTag()
 }  // END OF CLASS DEF
 

--- a/Drive_2_0_fieldCentric.java
+++ b/Drive_2_0_fieldCentric.java
@@ -279,7 +279,11 @@ public class Drive_2_0_fieldCentric extends LinearOpMode {
           armraise.setPower(0.265);
         } else {
           armraise.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
-          armraise.setPower(driverCmd_ArmRaise * MAX_ARM_RAISE_POWER);
+          if (armRaisePositionTicks > 683.55) {
+            armraise.setPower(0.33 * driverCmd_ArmRaise * MAX_ARM_RAISE_POWER);
+          } else {
+            armraise.setPower(driverCmd_ArmRaise * MAX_ARM_RAISE_POWER);
+          }
         }
       } else {  // isArmCmdDown
         isArmHolding = false;

--- a/RedBackPixel.java
+++ b/RedBackPixel.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 
 @Autonomous(name = "RedBackPixel")
 public class RedBackPixel extends LinearOpMode 
@@ -13,6 +14,8 @@ public class RedBackPixel extends LinearOpMode
   @Override
   public void runOpMode() 
   {
+    double xAdjustment = 0, yAdjustment = 0;  // default to no adjustments in case our tag isn't detected
+
     // See FindPropVisInitData.java for calibration guide
     FindPropVisInitData visInitData = new FindPropVisInitData();
     visInitData.ColorChannel = 1;               // channel 1: red, channel 2: blue
@@ -42,6 +45,7 @@ public class RedBackPixel extends LinearOpMode
     }
 
     lib.FindPropSetEnableDetection(false);
+    lib.initAprilTag();
 
     // wait for user to press start on Driver Station
     waitForStart();
@@ -67,12 +71,16 @@ public class RedBackPixel extends LinearOpMode
         lib.drive(-4,0,0,DRIVE_POWER);        // back slightly away
         lib.drive(0, 0, (-15), DRIVE_POWER);  // CCW to face away from backdrop
         lib.armraise(100, 0.3);               // raise arm (quickly / most of way for placing pixel on board)
-        lib.drive(-22.5, 0, 0, DRIVE_POWER);    // BACK toward backdrop
+        lib.drive(-19, 0, 0, DRIVE_POWER);    // BACK toward backdrop
         lib.drive(0, 10.5, 0, DRIVE_POWER);   // Right to left side of backdrop
         lib.reverseFlipper();                 // put flipper in rev pos for placing pixel on board
         lib.armraisewait(30, 0.09);           // slow down to avoid tipping over
 
-        lib.drive(-2.5, 0, 0, 0.2);             // REV last 5" to board
+        AprilTagDetection tagInfo = lib.getAprilTag_RedLeft();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);             // REV last 5" to board
         lib.openClampWait();                  // release pixel on board
         sleep(350);
         lib.drive(3, 0, 0, DRIVE_POWER);      // Get off of board
@@ -102,11 +110,16 @@ public class RedBackPixel extends LinearOpMode
         lib.drive(0, 0, -90, DRIVE_POWER);      // CCW 83 to face away from backdrop    
         sleep(50);
         lib.armraise(100, 0.3);                 // raise arm 120 deg (all the way back/up for placing pixel on board)
-        lib.drive(-21.5, 0, 0, DRIVE_POWER);    // BACK 25.5" toward backdrop
+        lib.drive(-20.5, 0, 0, DRIVE_POWER);    // BACK 25.5" toward backdrop
         lib.reverseFlipper();                   // put flipper in rev pos for placing pixel on board
         lib.drive(0, 4, 0, DRIVE_POWER);        // right 4" along backdrop to left pos
         lib.armraisewait(30, 0.127);            // slowly finish putting arm back
-        lib.drive(-5, 0, 0, 0.2);               // REV last 5" to board
+
+        AprilTagDetection tagInfo = lib.getAprilTag_RedMiddle();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);               // REV last 5" to board
         // Place pixel on backdrop
         lib.openClampLittleWait();              // release pixel on board
         sleep(300);
@@ -135,11 +148,16 @@ public class RedBackPixel extends LinearOpMode
         lib.drive(-3, 0, 0, DRIVE_POWER);     // back up 3"
         lib.drive(0, 0, -125, DRIVE_POWER);   // CCW 125 deg to face away from backdrop
         lib.armraise(100, 0.3);               // raise arm 120 deg (all the way back/up for placing pixel on board)
-        lib.drive(-25, 0, 0, DRIVE_POWER);    // Back 30" toward backdrop
+        lib.drive(-23.5, 0, 0, DRIVE_POWER);    // Back 30" toward backdrop
         lib.reverseFlipper();                 // put flipper in rev pos for placing pixel on board
         lib.drive(0, 2, 0, DRIVE_POWER);      // Slide right 1"
         lib.armraise(30, 0.127);              // slow down to avoid tipping over
-        lib.drive(-4.5, 0, 0, 0.2);           // REV last 5" to board
+
+        AprilTagDetection tagInfo = lib.getAprilTag_RedRight();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);           // REV last 5" to board
       // Place pixel on backdrop
         lib.openClampLittleWait();            // release pixel on board
         sleep(300);

--- a/RedBackPixel.java
+++ b/RedBackPixel.java
@@ -77,8 +77,8 @@ public class RedBackPixel extends LinearOpMode
         lib.armraisewait(30, 0.09);           // slow down to avoid tipping over
 
         AprilTagDetection tagInfo = lib.getAprilTag_RedLeft();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);             // REV last 5" to board
         lib.openClampWait();                  // release pixel on board
@@ -116,8 +116,8 @@ public class RedBackPixel extends LinearOpMode
         lib.armraisewait(30, 0.127);            // slowly finish putting arm back
 
         AprilTagDetection tagInfo = lib.getAprilTag_RedMiddle();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);               // REV last 5" to board
         // Place pixel on backdrop
@@ -154,8 +154,8 @@ public class RedBackPixel extends LinearOpMode
         lib.armraise(30, 0.127);              // slow down to avoid tipping over
 
         AprilTagDetection tagInfo = lib.getAprilTag_RedRight();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6 + yAdjustment, xAdjustment, 0, 0.2);           // REV last 5" to board
       // Place pixel on backdrop

--- a/RedFrontPixel.java
+++ b/RedFrontPixel.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 
 @Autonomous(name = "RedFrontPixel")
 public class RedFrontPixel extends LinearOpMode 
@@ -13,6 +14,8 @@ public class RedFrontPixel extends LinearOpMode
   @Override
   public void runOpMode() 
   {
+    double xAdjustment = 0, yAdjustment = 0;  // default to no adjustments in case our tag isn't detected
+
     // See FindPropVisInitData.java for calibration guide
     FindPropVisInitData visInitData = new FindPropVisInitData();
     visInitData.ColorChannel = 1;               // channel 1: red, channel 2: blue
@@ -42,6 +45,7 @@ public class RedFrontPixel extends LinearOpMode
     }
 
     lib.FindPropSetEnableDetection(false);
+    lib.initAprilTag();
 
     // wait for user to press start on Driver Station
     waitForStart();
@@ -67,13 +71,18 @@ public class RedFrontPixel extends LinearOpMode
         lib.drive(0, 0, 45, DRIVE_POWER); // Rotate 45 deg back to facing forward
         lib.drive(28, 0, 0, 0.65); // Forward 15" to middle of field
         lib.drive(0, 0, 90, 0.65); // Rotate 90 deg to face back
-        lib.drive(74, 0, 0, 0.65); // Forward 5'
+        lib.drive(74.5, 0, 0, 0.65); // Forward 5'
         lib.drive(0, 21, 0, 0.65);
-        lib.drive(0, 0, 180, 0.65);
+        lib.drive(0, 0, 180, 0.65); // turn around to back into backdrop
         lib.armraisewait(100,0.3);
         lib.reverseFlipper();
         lib.armraisewait(30,0.2);
-        lib.drive(-6.5,0,0,DRIVE_POWER);
+
+        AprilTagDetection tagInfo = lib.getAprilTag_RedLeft();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6.0 + yAdjustment,xAdjustment,0,DRIVE_POWER);
         lib.openClampWait();
         lib.drive(4.5,0,0,DRIVE_POWER);
         lib.normalFlipper();            // square w/ ground
@@ -97,13 +106,18 @@ public class RedFrontPixel extends LinearOpMode
         lib.drive(0, -10, 0, DRIVE_POWER);
         lib.drive(23, 0, 0, DRIVE_POWER);
         lib.drive(0, 0, 89, DRIVE_POWER);
-        lib.drive(91, 0, 0, 0.65);
+        lib.drive(90, 0, 0, 0.65);
         lib.drive(0, 23.5, 0, 0.65);
-        lib.drive(0, 0, 180, 0.65);
+        lib.drive(0, 0, 180, 0.65);  //turn around to back into backdrop
         lib.armraisewait(100, 0.2);
         lib.reverseFlipper();
         lib.armraisewait(30,0.2);
-        lib.drive(-5,0,0,DRIVE_POWER);
+
+        AprilTagDetection tagInfo = lib.getAprilTag_RedMiddle();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6 + yAdjustment,xAdjustment,0,DRIVE_POWER);
         lib.openClamp();
         lib.drive(3, 0, 0, DRIVE_POWER);
         lib.normalFlipper();
@@ -129,13 +143,18 @@ public class RedFrontPixel extends LinearOpMode
         lib.drive(0, 0, -50, DRIVE_POWER);
         lib.drive(25, 0, 0, DRIVE_POWER); // Forward 15" to middle of field
         lib.drive(0, 0, 90, DRIVE_POWER); // Rotate 90 deg to face back
-        lib.drive(79, 0, 0, DRIVE_POWER); // Forward 5' 7"
+        lib.drive(79.5, 0, 0, DRIVE_POWER); // Forward 5' 7"
         lib.drive(0, 33, 0, DRIVE_POWER);
-        lib.drive(0, 0, 180, DRIVE_POWER);
+        lib.drive(0, 0, 180, DRIVE_POWER);  //turn around to back into backdrop
         lib.armraisewait(100,0.3);
         lib.reverseFlipper();
         lib.armraisewait(30,0.2);
-        lib.drive(-6.5,0,0,DRIVE_POWER);
+
+        AprilTagDetection tagInfo = lib.getAprilTag_RedRight();
+        yAdjustment = getYAdjustmentForTag(tagInfo);
+        xAdjustment = getXAdjustmentForTag(tagInfo);
+
+        lib.drive(-6.0 + yAdjustment,xAdjustment,0,DRIVE_POWER);
         lib.openClampWait();
         lib.drive(4.5,0,0,DRIVE_POWER);
         lib.normalFlipper();            // square w/ ground

--- a/RedFrontPixel.java
+++ b/RedFrontPixel.java
@@ -79,8 +79,8 @@ public class RedFrontPixel extends LinearOpMode
         lib.armraisewait(30,0.2);
 
         AprilTagDetection tagInfo = lib.getAprilTag_RedLeft();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6.0 + yAdjustment,xAdjustment,0,DRIVE_POWER);
         lib.openClampWait();
@@ -114,8 +114,8 @@ public class RedFrontPixel extends LinearOpMode
         lib.armraisewait(30,0.2);
 
         AprilTagDetection tagInfo = lib.getAprilTag_RedMiddle();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6 + yAdjustment,xAdjustment,0,DRIVE_POWER);
         lib.openClamp();
@@ -151,8 +151,8 @@ public class RedFrontPixel extends LinearOpMode
         lib.armraisewait(30,0.2);
 
         AprilTagDetection tagInfo = lib.getAprilTag_RedRight();
-        yAdjustment = getYAdjustmentForTag(tagInfo);
-        xAdjustment = getXAdjustmentForTag(tagInfo);
+        yAdjustment = lib.getYAdjustmentForTag(tagInfo);
+        xAdjustment = lib.getXAdjustmentForTag(tagInfo);
 
         lib.drive(-6.0 + yAdjustment,xAdjustment,0,DRIVE_POWER);
         lib.openClampWait();

--- a/RedFrontPixel.java
+++ b/RedFrontPixel.java
@@ -41,12 +41,12 @@ public class RedFrontPixel extends LinearOpMode
       telemetry.addData(" -MIN_CHROMA: ", lib.FindPropMinChroma());
       telemetry.addData(" -MAX_X: ", lib.FindPropMaxX());
       telemetry.addData(" -MAX_Y: ", lib.FindPropMaxY());
+      telemetry.addData("Yaw", lib.getImuYaw());
       telemetry.update();
     }
 
     lib.FindPropSetEnableDetection(false);
     lib.initAprilTag();
-
     // wait for user to press start on Driver Station
     waitForStart();
 
@@ -70,8 +70,13 @@ public class RedFrontPixel extends LinearOpMode
         lib.drive(0, 6, 0, DRIVE_POWER); // Forward 15" to middle of field
         lib.drive(0, 0, 45, DRIVE_POWER); // Rotate 45 deg back to facing forward
         lib.drive(28, 0, 0, 0.65); // Forward 15" to middle of field
-        lib.drive(0, 0, 90, 0.65); // Rotate 90 deg to face back
-        lib.drive(74.5, 0, 0, 0.65); // Forward 5'
+        double imuRotation = lib.getImuYaw();
+        if (imuRotation != 0) {
+          lib.drive(0, 0, (90 + imuRotation), 0.65);      // Rotate CCW 90 dg to face back wall
+        } else {
+          lib.drive(0, 0, 90, 0);
+        }
+        lib.drive(74.5, 0, 0, 0.9); // Forward 5'
         lib.drive(0, 21, 0, 0.65);
         lib.drive(0, 0, 180, 0.65); // turn around to back into backdrop
         lib.armraisewait(100,0.3);
@@ -105,7 +110,12 @@ public class RedFrontPixel extends LinearOpMode
 
         lib.drive(0, -10, 0, DRIVE_POWER);
         lib.drive(23, 0, 0, DRIVE_POWER);
-        lib.drive(0, 0, 89, DRIVE_POWER);
+        double imuRotation = lib.getImuYaw();
+        if (imuRotation != 0) {
+          lib.drive(0, 0, (90 + imuRotation), 0.65);      // Rotate CCW 90 dg to face back wall
+        } else {
+          lib.drive(0, 0, 90, 0);
+        }
         lib.drive(90, 0, 0, 0.65);
         lib.drive(0, 23.5, 0, 0.65);
         lib.drive(0, 0, 180, 0.65);  //turn around to back into backdrop
@@ -142,7 +152,12 @@ public class RedFrontPixel extends LinearOpMode
         lib.drive(-2, -5, 0, DRIVE_POWER); // Slide left 7" to go around pixel/marker
         lib.drive(0, 0, -50, DRIVE_POWER);
         lib.drive(25, 0, 0, DRIVE_POWER); // Forward 15" to middle of field
-        lib.drive(0, 0, 90, DRIVE_POWER); // Rotate 90 deg to face back
+        double imuRotation = lib.getImuYaw();
+        if (imuRotation != 0) {
+          lib.drive(0, 0, (90 + imuRotation), 0.65);      // Rotate CCW 90 dg to face back wall
+        } else {
+          lib.drive(0, 0, 90, 0);
+        }
         lib.drive(79.5, 0, 0, DRIVE_POWER); // Forward 5' 7"
         lib.drive(0, 33, 0, DRIVE_POWER);
         lib.drive(0, 0, 180, DRIVE_POWER);  //turn around to back into backdrop


### PR DESCRIPTION
AutoCommon has added functions to init the _new_ rear webcam ("Webcam2") and use it for AprilTag detection.  Helper functions have been added to perform tag detection based on location description (isolating the magic numbers to just 1 place).

Functions to calculate the final drive adjustment based on the AprilTag pose data have also been added.  Because these functions assume that an additional command of `drive(-6.0, 0.0 ... )` will be performed, each of left/middle/right sections of these opmodes were refactored so the final (backwards) drive into the board is 6".

EndPropDetection was added to AutoCommon, but is not yet used.  It was intended to stop the OpenCV pipeline & close it down in case it was in conflict with AprilTags.  We ended up adding a separate camera with which we do AprilTag detection, so this turned out to not (yet) be an issue.